### PR TITLE
create-auto-update

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,7 +1,7 @@
 $(function() {
   function buildHTML(message){
-    if ( message.image ) {
-      var html = `<div class="message">
+    var image = ( message.image ) ? `<img class="lower-message__image" src=${message.image} >` : "";
+      var html = `<div class="message", data-message-id="${message.id}">
                     <div class="message__info">
                       <p class="message__info__talker">
                         ${message.user_name}
@@ -14,29 +14,12 @@ $(function() {
                       <p class="lower-message__content">
                         ${message.content}
                       </p>
+                        ${image}
                     </div>
-                      <img class="lower-message__image" src=${message.image} >
                   </div>`
                 return html;
-    } else {
-      var html =`<div class="message">
-                  <div class="message__info">
-                    <p class="message__info__talker">
-                      ${message.user_name}
-                    </p>
-                    <p class="message__info__data">
-                      ${message.created_at}
-                    </p>
-                  </div>
-                  <div class="lower-message">
-                    <p class="lower-message__content">
-                      ${message.content}
-                    </p>
-                  </div>
-                </div>`
-              return html;
             };
-          }
+
   $('#new_message').on('submit', function(e) {
     e.preventDefault();
     var formData = new FormData(this);
@@ -58,5 +41,32 @@ $(function() {
       .fail(function() {
         alert("メッセージ送信に失敗しました");
       });
-    })
-  });
+    });
+
+    var reloadMessages = function() {
+      var last_message_id = $('.message:last').data("message-id");
+      $.ajax({
+        url: 'api/messages',
+        type: 'get',
+        dataType: 'json',
+        data: {id: last_message_id}
+      })
+      .done(function(messages) {
+        if (messages.length !== 0) {
+          var insertHTML = '';
+          $.each(messages, function(i, message) {
+            insertHTML += buildHTML(message)
+          });
+          $('.messages').append(insertHTML);
+          $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+        }
+      })
+      .fail(function() {
+        alert('error');
+      });
+    };
+
+    if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+      setInterval(reloadMessages, 7000);
+    }
+});

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: {message: {id: message.id}}}
   .message__info
     %p.message__info__talker
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.content @message.content
 json.image @message.image.url
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
 json.user_name @message.user.name
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
#What
自動更新の実装をする、ブラウザをリロードすることなく投稿を反映させる
APIとして機能するコントローラーを作成し、json形式でレスポンスする

#Why
他のユーザーの投稿を自動で反映させるのに必要なため

#動作確認動画です
https://gyazo.com/f36f546dfe0ff494c26d4644487f05c9